### PR TITLE
Optional downloading of all preview images within the .files node

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ plugins: [
       objectTypes: ['SyncProduct', 'WarehouseProduct', 'Country', 'TaxRate'],
       apiKey: 'xxxxxxxxx',
       // optional params
-      downloadFiles: true,
+      downloadFiles: true, //enable file downloading in general
+      downloadProductThumbnail: true, //downloads the thumbnail of the product and the applied design
+      downloadProductImages: true, //downloads all other images (thumbnail + preview) that are coming from printful in .variant.files 
       imageDirectory: 'printful_images',
     },
   },


### PR DESCRIPTION
Hi @svengau ,

I´ve extended your library to not only download the thumbnail images, but also the previews of all files of a product.

Would be nice if you could merge it and release a new version, as this could improve (probably and hopefully) loading times a bit.

I´ve kept the option as it was, and extended it a bit:

```
      downloadFiles: true, //enable file downloading in general
      downloadProductThumbnail: true, //downloads the thumbnail of the product and the applied design
      downloadProductImages: true, //downloads all other images (thumbnail + preview) that are coming from printful in 
```

downloadFIles to enable it in general, downloadProductThumbnail is true by default to keep backwards compatibility and downloadProductImages is new and false by default.

By the way, I´ve contacted the Printful support because their API only deliveres two images, one mockup and the image you upload, and according to them its not possible to attach more and you have to do that by yourself.

How are you doing this? Are you just using those two images or do you merge the data coming from their API with products in your CMS?